### PR TITLE
Bug with ComparePerformance due to type confusion

### DIFF
--- a/TestPerformance.ipynb
+++ b/TestPerformance.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,12 +136,16 @@
     "    FolderName = \"Data/\"\n",
     "    Experiment = \"class_ 0_0_data\"\n",
     "    Label, Time, Ranking = TestClassification(FolderName,Experiment)\n",
+    "    Label = np.int64(Label)\n",
+    "    Time = np.int64(Time)\n",
     "    \n",
     "    RecordPerformance(Experiment, Label, Time, Ranking)\n",
     "    CutExperiment(FolderName,Experiment,Time)\n",
     "    \n",
     "    FolderName = \"Cut/\"\n",
     "    Label, Time, Ranking = TestClassification(FolderName,Experiment)\n",
+    "    Label = np.int64(Label)\n",
+    "    Time = np.int64(Time)\n",
     "    \n",
     "    Equal = ComparePerformance(Experiment,Label, Time, Ranking)\n",
     "    if(Equal==False):\n",
@@ -170,7 +174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hello PHME-DataChallenge-Team,

in preparation for submitting a data challenge solution, we reviewed our code and found a small bug in the evaluation workflow:

The problem statement required the TestClassification to return `Label` as string and `Time` as int. Later, when the values are read by the evaluation procedure (`Performance = pd.read_csv(...)` in multiple places), both values are converted to numpy.int64. The if-statement checking equality of the First- and Cut-prediction will return `False`, as the string <-> numpy.int64 comparison will not work. 

We inserted an explicit type conversion to fix this problem. The wording of the solution requirements might be misleading for other teams as well.

Best regards, 
Team PrIMA